### PR TITLE
Cargo.toml: Only package the `src` folder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ repository = "https://github.com/Turbo87/hosted-git-info-rs.git"
 edition = "2018"
 keywords = ["git", "github", "bitbucket", "gitlab"]
 license = "ISC"
+license-file = "LICENSE"
+include = ["/src"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
We probably shouldn't upload the `package-lock.json` file to crates.io 😅 